### PR TITLE
update helix-p4d to 2023.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This repository contains a collection of source files for building Docker images
 
 This directory contains the source files for building a Perforce Helix core server Docker image. The published Docker images are available as [`sourcegraph/helix-p4d` on Docker Hub](https://hub.docker.com/r/sourcegraph/helix-p4d).
 
+### Build the docker image
+
+The `helix-p4d/build.sh` script will build the docker image for you. If you don't provide a tag to the script it will tag the image as `sourcegraph/helix-p4d:latest`
+
+```
+./build.sh <tag>
+```
+
 ### Usage
 
 To have a disposable Perforce Helix core server running, simply do:

--- a/helix-p4d/Dockerfile
+++ b/helix-p4d/Dockerfile
@@ -8,8 +8,7 @@ LABEL vendor="Sourcegraph"
 LABEL maintainer="Joe Chen (joe@sourcegraph.com)"
 
 # Update Ubuntu and add Perforce Package Source
-RUN \
-  apt-get update && \
+RUN apt-get update && \
   apt-get install -y wget gnupg2 && \
   wget -qO - https://package.perforce.com/perforce.pubkey | apt-key add - && \
   echo "deb http://package.perforce.com/apt/ubuntu focal release" > /etc/apt/sources.list.d/perforce.list && \
@@ -22,10 +21,7 @@ RUN \
 # Create perforce user and install Perforce Server
 # Do in-page search over https://package.perforce.com/apt/ubuntu/dists/focal/release/binary-amd64/Packages
 # for both "Package: helix-p4d" and "Package: helix-swarm-triggers".
-RUN \
-  apt-get install -y helix-p4d=2023.1-2468153~focal && \
-  apt-get install -y helix-swarm-triggers=2023.1-2414875~focal
-
+RUN apt-get update && apt-get install -y helix-p4d=2023.2-2523307~focal helix-swarm-triggers=2023.4-2531655~focal
 # Add external files
 COPY files/restore.sh /usr/local/bin/restore.sh
 COPY files/setup.sh /usr/local/bin/setup.sh

--- a/helix-p4d/build.sh
+++ b/helix-p4d/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+tag=$1
+
+if [[ -z "$tag" ]]; then
+  tag="sourcegraph/helix-p4d:latest"
+fi
+
+docker build -t ${tag} --platform linux/amd64 .


### PR DESCRIPTION
Searched for the latest version of `helix-p4d` and `helix-swarm-triggers` on https://package.perforce.com/apt/ubuntu/dists/focal/release/binary-amd64/Packages