### PR TITLE
Update helix server to version 2024.1-2661979

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file helix-p4d/Dockerfile --tag jankonikola93/helix-p4d:$(date +%s)
+      run: docker build ./helix-p4d --file Dockerfile --tag jankonikola93/helix-p4d:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - 'main'
+    tags:
+      - 'v*'
 
 env:
-  REGISTRY: jankonikola93
-  IMAGE_NAME: helix-p4d
+  NAMESPACE: jankonikola93
+  REPOSITORY: helix-p4d
 
 jobs:
   push_to_registry:
@@ -23,9 +25,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v3.3.0
         with:
-          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
@@ -33,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+          images: ${{ env.NAMESPACE }}/${{ env.REPOSITORY }}
 
       - name: Build and push Docker image
         id: push
@@ -48,6 +49,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.NAMESPACE }}/${{ env.REPOSITORY}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,10 +6,8 @@ on:
       - 'main'
     tags:
       - 'v*'
-
-env:
-  NAMESPACE: jankonikola93
-  REPOSITORY: helix-p4d
+    paths-ignore:
+      - '-github/**'
 
 jobs:
   push_to_registry:
@@ -34,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.NAMESPACE }}/${{ env.REPOSITORY }}
+          images: ${{ vars.DOCKER_NAMESPACE }}/${{ vars.DOCKER_REPOSITORY }}
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,10 +44,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.NAMESPACE }}/${{ env.REPOSITORY}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          sbom: true
+          provenance: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,16 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file helix-p4d/Dockerfile --tag jankonikola93/helix-p4d:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - 'v*'
     paths-ignore:
-      - '-github/**'
+      - '.github/**'
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,10 +38,9 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6.9.0
         with:
           context: ./helix-p4d
-          file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,5 +44,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          sbom: true
-          provenance: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,16 +1,53 @@
-name: Docker Image CI
+name: Publish Docker image
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - 'main'
+
+env:
+  REGISTRY: jankonikola93
+  IMAGE_NAME: helix-p4d
 
 jobs:
-
-  build:
-
+  push_to_registry:
+    name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build ./helix-p4d --file Dockerfile --tag jankonikola93/helix-p4d:$(date +%s)
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./helix-p4d
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/helix-p4d/Dockerfile
+++ b/helix-p4d/Dockerfile
@@ -21,12 +21,12 @@ RUN apt-get update && \
 # Create perforce user and install Perforce Server
 # Do in-page search over https://package.perforce.com/apt/ubuntu/dists/focal/release/binary-amd64/Packages
 # for both "Package: helix-p4d" and "Package: helix-swarm-triggers".
-RUN apt-get update && apt-get install -y helix-p4d=2024.1-2625008~focal helix-swarm-triggers=2024.3-2628402~focal
+RUN apt-get update && apt-get install -y helix-p4d=2024.1-2661979~focal helix-swarm-triggers=2024.5-2666202~focal
 # Add external files
 COPY files/restore.sh /usr/local/bin/restore.sh
 COPY files/setup.sh /usr/local/bin/setup.sh
 COPY files/init.sh /usr/local/bin/init.sh
-# COPY files/latest_checkpoint.sh /usr/local/bin/latest_checkpoint.sh
+COPY files/latest_checkpoint.sh /usr/local/bin/latest_checkpoint.sh
 
 RUN \
   chmod +x /usr/local/bin/restore.sh && \

--- a/helix-p4d/Dockerfile
+++ b/helix-p4d/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y helix-p4d=2024.1-2625008~focal helix-sw
 COPY files/restore.sh /usr/local/bin/restore.sh
 COPY files/setup.sh /usr/local/bin/setup.sh
 COPY files/init.sh /usr/local/bin/init.sh
-COPY files/latest_checkpoint.sh /usr/local/bin/latest_checkpoint.sh
+# COPY files/latest_checkpoint.sh /usr/local/bin/latest_checkpoint.sh
 
 RUN \
   chmod +x /usr/local/bin/restore.sh && \


### PR DESCRIPTION
Helix server is updated to version 2024.1-2661979.
Github Action that can build and push image to docker hub is added.
If you want to configure this action to work in your repo you should create this variables on the repository level:
- DOCKER_NAMESPACE - your docker namespace
- DOCKER_REPOSITORY - name of the repository in your namespace you want to push image to

Also, you need to define this secrets values on the repository level:
- DOCKER_USERNAME
- DOCKER_PASSWORD

When you configure this, github action will push new version of the image on each new commit to main branch. This image will be tagged with main and latest tags.
If you want to create specific image tag you should create new tag with pattern 'v*' (v2024.1-2661979).

This is how it looks like on Docker Hub:
![image](https://github.com/user-attachments/assets/7e1b264c-b2da-4f81-b0a4-75bf9c4fb0c5)

If you want to disable github actions for your repository, you can do this in repository settings:
![image](https://github.com/user-attachments/assets/d10ea3cd-8978-4dab-b82d-4f525bbac187)
